### PR TITLE
fix: update environment variable names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,3 @@
 # Prefix with "PUBLIC_" to make available in Astro frontend files
-PUBLIC_SOROBAN_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
-PUBLIC_SOROBAN_RPC_URL="http://localhost:8000/soroban/rpc"
-
-SOROBAN_ACCOUNT="alice"
-SOROBAN_NETWORK="standalone"
+PUBLIC_STELLAR_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
+PUBLIC_STELLAR_RPC_URL="http://localhost:8000/rpc"

--- a/src/contracts/util.ts
+++ b/src/contracts/util.ts
@@ -1,9 +1,9 @@
-const envRPC = import.meta.env.PUBLIC_SOROBAN_RPC_URL;
+const envRPC = import.meta.env.PUBLIC_STELLAR_RPC_URL;
 export const rpcUrl =
   envRPC && typeof envRPC === "string"
     ? envRPC : "http://localhost:8000/rpc";
 
-const envNetworkPassphrase = import.meta.env.PUBLIC_NETWORK_PASSPHRASE;
+const envNetworkPassphrase = import.meta.env.PUBLIC_STELLAR_NETWORK_PASSPHRASE;
 export const networkPassphrase =
   envNetworkPassphrase && typeof envNetworkPassphrase === "string"
     ? envRPC : "Standalone Network ; February 2017";


### PR DESCRIPTION
- Make them use `STELLAR` instead of `SOROBAN`
- Replace `/soroban/rpc` with just `/rpc` — both options work with Quickstart, but `/rpc` has been the recommended way for a long time now