### PR TITLE
feat: typed wrapper around localStorage

### DIFF
--- a/src/components/WalletProvider/WalletProvider.tsx
+++ b/src/components/WalletProvider/WalletProvider.tsx
@@ -6,6 +6,7 @@ import {
   } from '@creit.tech/stellar-wallets-kit';
 import { Layout } from '@stellar/design-system';
 import { useEffect, useMemo, useState } from 'react';
+import storage from '../../util/storage'
 
 export const WalletProvider = () => {
     const [address, setAddress] = useState<string | null>(null);
@@ -29,8 +30,8 @@ export const WalletProvider = () => {
       if (hasInitialized) return;
       hasInitialized = true;
 
-      const savedWalletId = localStorage.getItem('walletId');
-      const currentSelected = localStorage.getItem('selectedModuleId');
+      const savedWalletId = storage.getItem('walletId');
+      const currentSelected = storage.getItem('selectedModuleId');
 
       if (savedWalletId && !address && currentSelected !== savedWalletId) {
         console.log("SAVED WALLET");
@@ -41,8 +42,8 @@ export const WalletProvider = () => {
           console.log("Connected to:", address);
         } catch (e) {
           console.warn("Failed to reconnect:", e);
-          localStorage.removeItem("walletId");
-          localStorage.removeItem("walletAddress");
+          storage.removeItem("walletId");
+          storage.removeItem("walletAddress");
         }
       }
 
@@ -52,17 +53,17 @@ export const WalletProvider = () => {
       await kit.createButton({
         container: walletContainer,
         onConnect: ({ address }) => {
-          const selectedWalletId = localStorage.getItem('selectedModuleId');
+          const selectedWalletId = storage.getItem('selectedModuleId');
           if (selectedWalletId) {
-            localStorage.setItem('walletId', selectedWalletId);
+            storage.setItem('walletId', selectedWalletId);
           }
-          localStorage.setItem('walletAddress', address);
+          storage.setItem('walletAddress', address);
           setAddress(address);
         },
         onDisconnect: () => {
           console.log("Wallet disconnected");
-          localStorage.removeItem("walletId");
-          localStorage.removeItem("walletAddress");
+          storage.removeItem("walletId");
+          storage.removeItem("walletAddress");
           setAddress("");
         }
       });

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -1,0 +1,86 @@
+/**
+ * A typed wrapper around localStorage largely borrowed from (but less capable
+ * than) https://www.npmjs.com/package/typed-local-store
+ *
+ * Provides a fully-typed interface to localStorage, and is easy to modify for other storage strategies (i.e. sessionStorage)
+ */
+
+
+/**
+ * Valid localStorage key names mapped to an arbitrary value of the correct
+ * type. Used to provide both good typing AND good type-ahead, so that you can
+ * see a list of valid storage keys while using this module elsewhere.
+ */
+const keys = {
+  walletId: 'a',
+  walletAddress: 'a',
+  selectedModuleId: 'a',
+};
+
+/**
+ * A mapped TypeScript type created from the run-time `keys` const above.
+ */
+type Schema = {
+  [K in keyof typeof keys]: typeof keys[K]
+};
+
+
+/**
+ * Typed interface that follows the Web Storage API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
+ *
+ * Implementation has been borrowed and simplified from https://www.npmjs.com/package/typed-local-store
+ */
+class TypedStorage<T> {
+  private readonly storage: Storage;
+
+  constructor() {
+    this.storage = localStorage
+  }
+
+  public get length(): number {
+    return this.storage?.length;
+  }
+
+  public key<U extends keyof T>(index: number): U {
+    return this.storage?.key(index) as U;
+  }
+
+  public getItem<U extends keyof T>(key: U, retrievalMode: 'fail' | 'raw' | 'safe' = 'fail'): T[U] | null {
+    const item = this.storage?.getItem(key.toString());
+
+    if (item == null) {
+      return item;
+    }
+
+    try {
+      return JSON.parse(item) as T[U];
+    } catch (error) {
+      switch (retrievalMode) {
+        case 'safe':
+          return null;
+        case 'raw':
+          return (item as unknown) as T[U];
+        default:
+          throw error;
+      }
+    }
+  }
+
+  public setItem<U extends keyof T>(key: U, value: T[U]): void {
+    this.storage?.setItem(key.toString(), JSON.stringify(value));
+  }
+
+  public removeItem<U extends keyof T>(key: U): void {
+    this.storage?.removeItem(key.toString());
+  }
+
+  public clear(): void {
+    this.storage?.clear();
+  }
+}
+
+/**
+ * Fully-typed wrapper around localStorage
+ */
+export default new TypedStorage<Schema>;
+


### PR DESCRIPTION
In #29, the raw calls to `localStorage` made me uneasy for a couple reasons:

1. Lots of strings! If the name of one of those keys gets mistyped, bad things will happen. Better to have type-checking on the strings, or to store them in constants, or something.
2. No types on the storage

A tricky thing here is that we are implementing a starting point for other projects. We want to provide something _minimal_, yet _powerful_. I confess that what I've added here might not qualify as "minimal"! 

I don't want these new projects to have unnecessary npm dependencies, so I re-implemented (a minimal version of) an existing library.

I think the `storage.ts` file is slim enough to be understandable, and has nice properties. If you define your `keys` like this:

<img width="241" alt="const keys = { walletId: 'a', walletAddress: 0 }" src="https://github.com/user-attachments/assets/f0caae58-4a73-49c6-9f5a-4548a07428a0" />

Then when you import `storage` elsewhere, you get this typeahead on `getItem`:

<img width="1028" alt="a tooltip over 'getItem' shows that the first argument can be either 'walletId' or 'walletAddress'" src="https://github.com/user-attachments/assets/96651a91-76bf-45a4-b129-468cbb4094f0" />

And the return types for keys of different types are all well-typed:

<img width="545" alt="the type returned by 'walletAddress' is a number" src="https://github.com/user-attachments/assets/58b84309-efde-4d7d-9f52-7449523c68d1" />

<img width="553" alt="the type returned by 'walletId' is a string" src="https://github.com/user-attachments/assets/9f80a7d9-b0e4-4758-952e-2f92cbfe4852" />
