### PR TITLE
Change stellar scaffold command name from dev to watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "concurrently \"stellar scaffold dev --build-clients\" \"vite\"",
-    "start": "concurrently \"stellar scaffold dev --build-clients\" \"vite\"",
+    "dev": "concurrently \"stellar scaffold watch --build-clients\" \"vite\"",
+    "start": "concurrently \"stellar scaffold watch --build-clients\" \"vite\"",
     "build": "tsc -b && vite build",
     "install:contracts": "npm install --workspace=packages && npm run build --workspace=packages",
     "preview": "vite preview",


### PR DESCRIPTION
## Why
Working on integrating scaffoling-cli project on OpenZeppelin Wizard when initiating new project encountering `error: unrecognized subcommand 'dev'`

## Description
Following [this change](https://github.com/AhaLabs/scaffold-stellar/pull/56) (from `dev` to `watch` command) in the scaffold-cli, the dev command in the `package.json` that call scaffold cli should call watch instead of dev.
Making this change will allow running the `npm dev` command in the scaffolded project from the cli, instead of running into `error: unrecognized subcommand 'dev'` error