### PR TITLE
feat: add network display user

### DIFF
--- a/src/components/ConnectAccount.tsx
+++ b/src/components/ConnectAccount.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 import { stellarNetwork } from '../contracts/util';
 import FundAccountButton from './FundAccountButton';
 import { WalletButton } from './WalletButton';
+import NetworkPill from './NetworkPill';
 
 const ConnectAccount: React.FC = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '10px', verticalAlign: 'middle' }}>
+        <NetworkPill />
         <WalletButton />
         {stellarNetwork !== "mainnet" && <FundAccountButton />}
     </div>

--- a/src/components/NetworkPill.tsx
+++ b/src/components/NetworkPill.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Icon } from '@stellar/design-system';
+import { useWallet } from '../hooks/useWallet';
+import { stellarNetwork } from '../contracts/util';
+
+const NetworkPill: React.FC = () => {
+  const { network, address } = useWallet();
+  
+  // Determine network display name
+  const networkName = stellarNetwork || 'local';
+  
+  // Check if there's a network mismatch
+  const isNetworkMismatch = address && network && network.toUpperCase() !== stellarNetwork.toUpperCase();
+  
+  const bgColor = '#F0F2F5';
+  const textColor = '#4A5362';
+  
+  // Green when connected (and networks match), red when mismatch, gray when not connected
+  const circleColor = !address ? '#C1C7D0' : isNetworkMismatch ? '#FF3B30' : '#2ED06E';
+
+  // Format network name with first letter capitalized
+  const formatNetworkName = (name: string) => 
+    name.charAt(0).toUpperCase() + name.slice(1).toLowerCase();
+    
+  // Create mismatch message for hover tooltip with proper capitalization
+  const mismatchMessage = isNetworkMismatch 
+    ? `Network mismatch: App is on ${formatNetworkName(stellarNetwork)}, wallet is on ${formatNetworkName(network)}`
+    : '';
+
+  return (
+    <div 
+      style={{
+        backgroundColor: bgColor,
+        color: textColor,
+        padding: '4px 10px',
+        borderRadius: '16px',
+        fontSize: '12px',
+        fontWeight: 'bold',
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        cursor: isNetworkMismatch ? 'help' : 'default'
+      }}
+      title={mismatchMessage}
+    >
+      <Icon.Circle color={circleColor} />
+      {formatNetworkName(networkName)}
+    </div>
+  );
+};
+
+export default NetworkPill;


### PR DESCRIPTION
Adds a network pill component to display app's network to user

![image](https://github.com/user-attachments/assets/3b7329cb-fdef-4b0b-972d-c1c16611e9a2)

If the user's wallet is not connected the circle indicator is grey, if they are connected and on the same network as the app the indicator is green, if on a different network its red and a tooltip says that they are not on the same network as the app.