### PR TITLE
Update friendbot URL situation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ function getFriendbotHost(mode: string) {
   const env = loadEnv(mode, process.cwd(), '')
   switch (env.PUBLIC_STELLAR_NETWORK) {
     case "local":
-      return "http://localhost:8000";
+      return "http://localhost:8000/friendbot";
     case "futurenet":
       return "https://friendbot-futurenet.stellar.org";
     case "testnet":
@@ -33,6 +33,7 @@ export default defineConfig(({ mode }) => {
         '/friendbot': {
           target: getFriendbotHost(mode),
           changeOrigin: true,
+          rewrite: (path) => path.replace(/^\/friendbot/, ''),
         },
       }
     }


### PR DESCRIPTION
Indeed, the friendbot URL needed to change since at other URLs, it's not `/friendbot`.

This fixes running the app in testnet.