### PR TITLE
feat: Move account balance to header bar/out of tooltip

### DIFF
--- a/src/components/ConnectAccount.tsx
+++ b/src/components/ConnectAccount.tsx
@@ -15,9 +15,9 @@ const ConnectAccount: React.FC = () => {
         verticalAlign: "middle",
       }}
     >
-      <NetworkPill />
       <WalletButton />
       {stellarNetwork !== "mainnet" && <FundAccountButton />}
+      <NetworkPill />
     </div>
   );
 };

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -24,10 +24,8 @@ export const WalletButton = () => {
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
-        verticalAlign: "middle",
         gap: "10px",
         opacity: balance.isLoading ? 0.6 : 1,
-        float: "left",
       }}
     >
       <Text as="div" size="sm">

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -1,17 +1,10 @@
 import { useState } from "react";
-import {
-  Button,
-  Layout,
-  Modal,
-  Profile,
-  Tooltip,
-} from "@stellar/design-system";
+import { Button, Text, Modal, Profile } from "@stellar/design-system";
 import { useWallet } from "../hooks/useWallet";
 import { useWalletBalance } from "../hooks/useWalletBalance";
 import { connectWallet, disconnectWallet } from "../util/wallet";
 
 export const WalletButton = () => {
-  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const [showDisconnectModal, setShowDisconnectModal] = useState(false);
   const { address, isPending } = useWallet();
   const { xlm, ...balance } = useWalletBalance();
@@ -25,14 +18,22 @@ export const WalletButton = () => {
     );
   }
 
-  const showTooltip = () => {
-    void balance.updateBalance();
-    if (balance.error) return;
-    setIsTooltipVisible(true);
-  };
-
   return (
-    <Layout.Content>
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        verticalAlign: "middle",
+        gap: "10px",
+        opacity: balance.isLoading ? 0.6 : 1,
+        float: "left",
+      }}
+    >
+      <Text as="div" size="sm">
+        Wallet Balance: {xlm} XLM
+      </Text>
+
       <div id="modalContainer">
         <Modal
           visible={showDisconnectModal}
@@ -69,29 +70,12 @@ export const WalletButton = () => {
         </Modal>
       </div>
 
-      <div
-        onMouseEnter={showTooltip}
-        onMouseLeave={() => setIsTooltipVisible(false)}
-      >
-        <Tooltip
-          isVisible={isTooltipVisible}
-          isContrast
-          title="Wallet Balance"
-          placement="bottom"
-          triggerEl={
-            <Profile
-              publicAddress={address}
-              size="md"
-              isShort
-              onClick={() => setShowDisconnectModal(true)}
-            />
-          }
-        >
-          <span style={{ opacity: balance.isLoading ? 0.6 : 1 }}>
-            {xlm} XLM
-          </span>
-        </Tooltip>
-      </div>
-    </Layout.Content>
+      <Profile
+        publicAddress={address}
+        size="md"
+        isShort
+        onClick={() => setShowDisconnectModal(true)}
+      />
+    </div>
   );
 };

--- a/src/components/WalletButton.tsx
+++ b/src/components/WalletButton.tsx
@@ -24,7 +24,7 @@ export const WalletButton = () => {
         display: "flex",
         flexDirection: "row",
         alignItems: "center",
-        gap: "10px",
+        gap: "5px",
         opacity: balance.isLoading ? 0.6 : 1,
       }}
     >


### PR DESCRIPTION
At this week's checkin, we got some feedback to move the balance out of the tooltip and into the header itself.

This moves account balance out of tooltip and into header bar and moves the network pill to side to allow left expansion so that things don't shift around when the balance appears.

<img width="597" alt="Screenshot 2025-06-11 at 10 21 03 AM" src="https://github.com/user-attachments/assets/ecba93f9-630c-4f5c-8ef9-4384a767994a" />

