### PR TITLE
Update package-lock after building packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13246,7 +13246,7 @@
     "packages/fungible_token_interface_example": {
       "version": "0.0.0",
       "dependencies": {
-        "@stellar/stellar-sdk": "13.0.0",
+        "@stellar/stellar-sdk": "^13.x",
         "buffer": "6.0.3"
       },
       "devDependencies": {
@@ -13301,7 +13301,7 @@
     "packages/soroban_hello_world_contract": {
       "version": "0.0.0",
       "dependencies": {
-        "@stellar/stellar-sdk": "13.0.0",
+        "@stellar/stellar-sdk": "^13.x",
         "buffer": "6.0.3"
       },
       "devDependencies": {


### PR DESCRIPTION
Steps:

- Ran `STELLAR_SCAFFOLD_ENV=development stellar scaffold build --build-clients`
- Ran `npm i`

Got the following update, which makes the stellar-sdk dependency more flexible for our contracts, it seems.