### PR TITLE
fix!: fully deprecate standalone network label

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Prefix with "PUBLIC_" to make available in frontend files
 # Which Stellar network to use in the frontend: local, testnet, futurenet, or mainnet
 # More on Stellar networks: https://developers.stellar.org/docs/networks
-PUBLIC_STELLAR_NETWORK="local"
+PUBLIC_STELLAR_NETWORK="LOCAL"
 # The Stellar network passphrase, this is local
 PUBLIC_STELLAR_NETWORK_PASSPHRASE="Standalone Network ; February 2017"
 # The Stellar network RPC URL. this is local

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,12 @@ import prettier from "eslint-config-prettier";
 import { globalIgnores } from "eslint/config";
 
 export default tseslint.config(
-  globalIgnores(["dist", "packages", "src/contracts"]),
+  globalIgnores([
+    "dist",
+    "packages",
+    "src/contracts/*",
+    "!src/contracts/util.ts",
+  ]),
   {
     extends: [
       js.configs.recommended,

--- a/src/contracts/util.ts
+++ b/src/contracts/util.ts
@@ -23,7 +23,10 @@ const env: z.infer<typeof envSchema> = parsed.success
       PUBLIC_STELLAR_RPC_URL: "http://localhost:8000/rpc",
     };
 
-export const stellarNetwork = env.PUBLIC_STELLAR_NETWORK;
+export const stellarNetwork =
+  env.PUBLIC_STELLAR_NETWORK === "STANDALONE"
+    ? "LOCAL"
+    : env.PUBLIC_STELLAR_NETWORK;
 export const networkPassphrase = env.PUBLIC_STELLAR_NETWORK_PASSPHRASE;
 
 // NOTE: needs to be exported for contract files in this directory

--- a/src/util/friendbot.ts
+++ b/src/util/friendbot.ts
@@ -3,7 +3,7 @@ import { stellarNetwork } from "../contracts/util";
 // Utility to get the correct Friendbot URL based on environment
 export function getFriendbotUrl(address: string) {
   switch (stellarNetwork) {
-    case "STANDALONE":
+    case "LOCAL":
       // Use proxy in development for local
       return `/friendbot?addr=${address}`;
     case "FUTURENET":

--- a/src/util/wallet.ts
+++ b/src/util/wallet.ts
@@ -39,7 +39,7 @@ export const disconnectWallet = async () => {
 
 function getHorizonHost(mode: string) {
   switch (mode) {
-    case "STANDALONE":
+    case "LOCAL":
       return "http://localhost:8000";
     case "FUTURENET":
       return "https://horizon-futurenet.stellar.org";
@@ -54,7 +54,7 @@ function getHorizonHost(mode: string) {
 
 export const fetchBalance = async (address: string) => {
   const horizon = new Horizon.Server(getHorizonHost(stellarNetwork), {
-    allowHttp: stellarNetwork === "STANDALONE",
+    allowHttp: stellarNetwork === "LOCAL",
   });
 
   const { balances } = await horizon.accounts().accountId(address).call();


### PR DESCRIPTION
Update .env.example to use "LOCAL" string and picks Horizon endpoint accordingly