### PR TITLE
Chore: use default build strategy

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,8 +12,6 @@ env:
 
 jobs:
   build:
-    strategy:
-      fail-fast: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Defining a strategy requires defining a matrix of job configurations but we don't need one for our use case. And since we only have one job instance, it will fail fast by default.