### PR TITLE
fix: Remove outdated comment

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,3 @@
-# Stellar VM issue with smart contracts
-# See https://discord.com/channels/897514728459468821/1314331742097772565/1316256311691841548
 [toolchain]
 channel = "1.86.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
We previously tagged to an older edition of rust and had a comment clarifying why. This is no longer needed, so remove.