### PR TITLE
Add metadata.stellar to hello world

### DIFF
--- a/contracts/hello_world/Cargo.toml
+++ b/contracts/hello_world/Cargo.toml
@@ -7,6 +7,10 @@ repository.workspace = true
 publish = false
 version.workspace = true
 
+[package.metadata.stellar]
+# Set contract metadata for authors, homepage, and version based on the Cargo.toml package values
+cargo_inherit = true 
+
 [lib]
 crate-type = ["cdylib"]
 doctest = false


### PR DESCRIPTION
Add metadata block to our hello world contract; OZ contracts need to be updated by OZ since we update them live with `init` … so those can be updated in this repo when new versions are out with the metadata block