### PR TITLE
Update rust toolchain to 1.88.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 targets = ["wasm32v1-none"]


### PR DESCRIPTION
## Motivation
Currently running `upgrade` command with the latest `stellar-contract-utils-0.4.1` the following error is raised

```
error[E0658]: use of unstable library feature `unsigned_is_multiple_of`
   --> index.crates.io-1949cf8c6b5b557f/stellar-contract-utils-0.4.1/src/crypto/merkle.rs:102:29
    |
102 |             leaf = if index.is_multiple_of(2) {
    |                             ^^^^^^^^^^^^^^
    |
    = note: see issue #128101 <https://github.com/rust-lang/rust/issues/128101> for more information
```

This error as been resolved in latest rustc stable version `1.88.0` suggesting using this latest stable version in `rust-toolchain.toml` to avoid logging this error upon upgrading.

## Description
Updating rustc version to `1.88.0` in `rust-toolchain.toml`