### PR TITLE
Better debug page empty state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1154,13 +1154,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+      "integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1168,9 +1168,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9266,9 +9266,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",

--- a/src/pages/Debugger.tsx
+++ b/src/pages/Debugger.tsx
@@ -60,6 +60,23 @@ const Debugger: React.FC = () => {
       <Layout.Content>
         <Layout.Inset>
           <p>No contracts found in src/contracts/</p>
+          <p>
+            Do you have any contracts defined in your root{" "}
+            <Code size="sm">contracts</Code> folder, and defined in your
+            environments.toml file?
+          </p>
+          <p>
+            Use <Code size="sm">stellar scaffold generate contract</Code> to
+            install contracts from the{" "}
+            <a href="https://github.com/OpenZeppelin/stellar-contracts">
+              OpenZeppelin Stellar Contracts
+            </a>{" "}
+            repository, or visit the{" "}
+            <a href="https://wizard.openzeppelin.com/stellar">
+              OpenZeppelin Wizard
+            </a>{" "}
+            to interactively build your contract.
+          </p>
         </Layout.Inset>
       </Layout.Content>
     );


### PR DESCRIPTION
Closes https://github.com/AhaLabs/scaffold-stellar/issues/145

Add some guidance to point users to where they can download contracts if they have none.

<img width="2506" height="604" alt="image" src="https://github.com/user-attachments/assets/3efeecd8-c3c2-4389-834c-44cf3556e7df" />

Also fixes an `npm audit` check