### PR TITLE
docs: link to main Scaffold Stellar repo at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scaffold Stellar Frontend
 
+_To get started with Scaffold Stellar, visit its repo: [github.com/AhaLabs/scaffold-stellar](https://github.com/AhaLabs/scaffold-stellar). This repository is only the frontend piece._
+
 _Under active development._
 
 A modern, up-to-date toolkit for building Stellar smart contract frontends.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Scaffold Stellar Frontend
 
-_To get started with Scaffold Stellar, visit its repo: [github.com/AhaLabs/scaffold-stellar](https://github.com/AhaLabs/scaffold-stellar). This repository is only the frontend piece._
+_To get started with Scaffold Stellar, visit its repo: [github.com/AhaLabs/scaffold-stellar](https://github.com/AhaLabs/scaffold-stellar)._
 
 _Under active development._
 


### PR DESCRIPTION
Sometimes people find this repository first and aren't sure what to do. This tells them to check the other/main repository for instructions.