### PR TITLE
fix: refresh wallet balance when address changes

### DIFF
--- a/src/hooks/useWalletBalance.ts
+++ b/src/hooks/useWalletBalance.ts
@@ -65,7 +65,7 @@ export const useWalletBalance = () => {
 
   useEffect(() => {
     void updateBalance();
-  }, [updateBalance]);
+  }, [address, updateBalance]);
 
   return {
     ...state,


### PR DESCRIPTION
We shouldn't need a refresh of the page to show the latest wallet
balance.

In theory this fixes it, re-firing the `useEffect` hook to get the
latest balance every time the address changes.

In actuality, I have not been able to test it because I think I have
Freighter bugs? When I try to add a second address to my wallet, I
start getting errors in the Freighter interface that just say:

    An unexpected error has occurred
    TypeError: can't access property "status", v is undefined

- [ ] figure out if this is a just-me thing (I tried Zen (Firefox-based)
  and Arc (Chrome-based) and get the error in both versions of
  Freighter) or a Freighter thing
- [ ] if Freighter, report bug to them