### PR TITLE
Update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7126,6 +7126,7 @@
       "integrity": "sha512-unn6Vy/Yke6F99vg/7tcrvM2KUvIhTNniaSqDbam4AWkd4NhvDVSrQiRYVlNzUV2P7SPobkCK7JFVxrJk9btCg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-module-resolve": "^1.10.0",
         "bare-semver": "^1.0.0"
@@ -7145,6 +7146,7 @@
       "integrity": "sha512-DCxeT9i8sTs3vUMA3w321OX/oXtNEu5EjObQOnTmCdNp5RXHBAvAaBDHvAi9ta0q/948QPz+co6SsGi6aQMYRg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-semver": "^1.0.0"
       },
@@ -7163,6 +7165,7 @@
       "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -7173,6 +7176,7 @@
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -7182,7 +7186,8 @@
       "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.1.tgz",
       "integrity": "sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==",
       "license": "Apache-2.0",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/bare-url": {
       "version": "2.1.6",
@@ -7190,6 +7195,7 @@
       "integrity": "sha512-FgjDeR+/yDH34By4I0qB5NxAoWv7dOTYcOXwn73kr+c93HyC2lU6tnjifqUe33LKMJcDyCYPQjEAqgOQiXkE2Q==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -9410,10 +9416,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/fungible_token_interface_example": {
-      "resolved": "packages/fungible_token_interface_example",
-      "link": true
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
@@ -12149,6 +12151,7 @@
       "integrity": "sha512-KbXAD5q2+v1GJnkzd8zzbOxchTkStSyJZ9QwoCq3QwEXAaIlG3wDYRZGzVD357jmwaGY7hr5VaoEAL0BkF0Kvg==",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bare-addon-resolve": "^1.3.0",
         "bare-url": "^2.1.0"
@@ -12637,16 +12640,23 @@
       "peer": true
     },
     "node_modules/sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
       "license": "(MIT AND BSD-3-Clause)",
       "dependencies": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
       },
       "bin": {
         "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sha1": {
@@ -12849,6 +12859,7 @@
       "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "require-addon": "^1.1.0"
       }
@@ -12861,10 +12872,6 @@
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
-    },
-    "node_modules/soroban_hello_world_contract": {
-      "resolved": "packages/soroban_hello_world_contract",
-      "link": true
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -13259,7 +13266,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
       "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isarray": "^2.0.5",
@@ -13274,7 +13280,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
@@ -13432,7 +13437,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
       "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -14404,57 +14408,13 @@
     },
     "packages/fungible_token_interface_example": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "13.0.0",
         "buffer": "6.0.3"
       },
       "devDependencies": {
         "typescript": "^5.6.2"
-      }
-    },
-    "packages/fungible_token_interface_example/node_modules/@stellar/stellar-base": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
-      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.3.3"
-      }
-    },
-    "packages/fungible_token_interface_example/node_modules/@stellar/stellar-sdk": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.0.0.tgz",
-      "integrity": "sha512-+wvmKi+XWwu27nLYTM17EgBdpbKohEkOfCIK4XKfsI4WpMXAqvnqSm98i9h5dAblNB+w8BJqzGs1JY0PtTGm4A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^13.0.1",
-        "axios": "^1.7.7",
-        "bignumber.js": "^9.1.2",
-        "eventsource": "^2.0.2",
-        "feaxios": "^0.0.20",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      }
-    },
-    "packages/fungible_token_interface_example/node_modules/feaxios": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.20.tgz",
-      "integrity": "sha512-g3hm2YDNffNxA3Re3Hd8ahbpmDee9Fv1Pb1C/NoWsjY7mtD8nyNeJytUzn+DK0Hyl9o6HppeWOrtnqgmhOYfWA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-retry-allowed": "^3.0.0"
       }
     },
     "packages/nft_enumerable_example": {
@@ -14470,51 +14430,13 @@
     },
     "packages/soroban_hello_world_contract": {
       "version": "0.0.0",
+      "extraneous": true,
       "dependencies": {
         "@stellar/stellar-sdk": "^13.x",
         "buffer": "6.0.3"
       },
       "devDependencies": {
         "typescript": "^5.6.2"
-      }
-    },
-    "packages/soroban_hello_world_contract/node_modules/@stellar/stellar-base": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-13.1.0.tgz",
-      "integrity": "sha512-90EArG+eCCEzDGj3OJNoCtwpWDwxjv+rs/RNPhvg4bulpjN/CSRj+Ys/SalRcfM4/WRC5/qAfjzmJBAuquWhkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/js-xdr": "^3.1.2",
-        "base32.js": "^0.1.0",
-        "bignumber.js": "^9.1.2",
-        "buffer": "^6.0.3",
-        "sha.js": "^2.3.6",
-        "tweetnacl": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "optionalDependencies": {
-        "sodium-native": "^4.3.3"
-      }
-    },
-    "packages/soroban_hello_world_contract/node_modules/@stellar/stellar-sdk": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-13.3.0.tgz",
-      "integrity": "sha512-8+GHcZLp+mdin8gSjcgfb/Lb6sSMYRX6Nf/0LcSJxvjLQR0XHpjGzOiRbYb2jSXo51EnA6kAV5j+4Pzh5OUKUg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@stellar/stellar-base": "^13.1.0",
-        "axios": "^1.8.4",
-        "bignumber.js": "^9.3.0",
-        "eventsource": "^2.0.2",
-        "feaxios": "^0.0.23",
-        "randombytes": "^2.1.0",
-        "toml": "^3.0.0",
-        "urijs": "^1.19.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "packages/soroban_token_contract": {


### PR DESCRIPTION
Fixes this audit issue and cleans up other package-lock cruft.

```
sha.js  <=2.4.11
Severity: critical
sha.js is missing type checks leading to hash rewind and passing on crafted data - https://github.com/advisories/GHSA-95m3-7q98-8xr5
fix available via `npm audit fix`
node_modules/sha.js
```